### PR TITLE
add Adalight support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ A new string is emitted every 256 samples (adjustable with `-b` option); that am
 It should be trivial to convert the `pianolizer` output into a static spectrogram image (TODO).
 When using a microphone source on a Raspberry Pi, use [arecord](https://linux.die.net/man/1/arecord).
 
+### Desktop Linux
+
+On a desktop linux pc - without any 'native' gpios - it is possible to use an arduino that is running an [AdaLight (or compatible) sketch](https://github.com/hyperion-project/hyperion.ng/blob/master/assets/firmware/arduino/adalight/adalight.ino).
+Capturing and visualizing the audio that Pulse-Audio receives and pipes to it's speakers:
+
+```
+RATE=22050
+pacat --record --rate $RATE --device=alsa_output.pci-0000_00_1b.0.analog-stereo.monitor | \
+    ffmpeg -f s16le -ar $RATE -ac 2 -i - -f f32le -ar $RATE -ac 1 - | \
+    ./pianolizer -s $RATE -t 0.03 -a 0.02 | ./misc/hex2adalight.py /dev/ttyACM0
+```
+Note that [pacat](https://linux.die.net/man/1/pacat) also can directly convert to '--format float32le', but for some reason leaving this up to ffmpeg introduces less latency between notes beeing played and the visualization showing the corresponding keys.
+
 ### Raspberry Pi specific
 
 The included [Python script](misc/hex2ws281x.py) consumes the hexadecimal output of `pianolizer` and drives a WS2812B LED strip (depends on the [rpi_ws281x library](https://github.com/rpi-ws281x/rpi-ws281x-python)).

--- a/misc/hex2adalight.py
+++ b/misc/hex2adalight.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import serial
+import colorsys
+import sys
+import re
+
+from palette import Palette
+
+LEDS_PER_KEY = 2
+LED_OFFSET = 3
+
+ttydev = sys.argv[1]
+if not 'dev/tty' in ttydev:
+    print("missing expected /dev/tty* as parameter")
+    sys.exit(1)
+
+ser = serial.Serial(ttydev, 115200)
+
+def send_line(line):
+    rgb_data = bytearray()
+    rgb_data.extend([0] * 3 * LED_OFFSET * LEDS_PER_KEY)
+    levels = [c / 255 for c in bytes.fromhex(match.group())]
+    for rgb in palette.getKeyColors(levels):
+        rgb_data.extend(rgb*LEDS_PER_KEY)
+
+    l = int( len(rgb_data) / 3 ) -1
+    hi = l>>8
+    lo = l&0xff
+
+    # Calculate the checksum
+    chk = hi ^ lo ^ 0x55
+
+    # Send the data
+    data = b"Ada" + bytes([hi, lo, chk]) + rgb_data
+    ser.write(data)
+    ser.flush()
+
+KEYS = 61
+validator = re.compile(r'^\s*[0-9a-f]{%d}\b' % (KEYS * 2), re.IGNORECASE)
+palette = Palette('palette.json')
+
+skip=0
+for line in sys.stdin:
+    match = validator.match(line)
+    if match:
+        ## don't transfer every line, since this introduces lag/latency as the data has to go through a serial-line
+        skip+=1
+        if skip > 2:
+            skip=0
+            send_line(match.group())
+    else:
+        print(f'bad input: {line.strip()}')
+
+ser.close()


### PR DESCRIPTION
adalight is a small sketch to bridge usb>ws2821, that uses a simple serial protocol to receive rgb data and switch the connected led strip accordingly

this PR adds the converter script, and adds an example to the usage section in the readme

the sketch i used was a forked/"archived" version in the hyperiond repository... but looking at the official adafruit git, the protocol seems to be unchanged 
